### PR TITLE
feat: calculate average ping amounts instead of raw ping

### DIFF
--- a/drizzle/0003_broad_donald_blake.sql
+++ b/drizzle/0003_broad_donald_blake.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `historic_ping_avg` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`ping` integer,
+	`time` integer NOT NULL
+);

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,192 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "19f9f083-c539-433a-8b03-d80bd08d1aad",
+  "prevId": "cacb2b09-12f4-4fc4-a4d9-ad883f84da28",
+  "tables": {
+    "historic_ping": {
+      "name": "historic_ping",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ping": {
+          "name": "ping",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "historic_ping_avg": {
+      "name": "historic_ping_avg",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ping": {
+          "name": "ping",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "incident_updates": {
+      "name": "incident_updates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "incidentId": {
+          "name": "incidentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "incident_updates_incidentId_incidents_id_fk": {
+          "name": "incident_updates_incidentId_incidents_id_fk",
+          "tableFrom": "incident_updates",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incidentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "incidents": {
+      "name": "incidents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1780235568228,
       "tag": "0002_bizarre_rafael_vega",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1781090970433,
+      "tag": "0003_broad_donald_blake",
+      "breakpoints": true
     }
   ]
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,8 +1,9 @@
 import { env } from '$env/dynamic/private';
 import cron from 'node-cron';
 
+import { desc, gte } from 'drizzle-orm';
 import { db } from '$lib/server/db';
-import { historicPing } from '$lib/server/db/schema';
+import { historicPing, historicPingAvg } from '$lib/server/db/schema';
 
 import type { botStatus } from '$lib/interfaces/status';
 
@@ -22,6 +23,23 @@ cron.schedule('* * * * *', async () => {
 
     const data: botStatus = await request.json();
     await db.insert(historicPing).values({ ping: data.latency });
+
+    // get around the last 3-4 minutes to calculate average
+    const fourMinutesAgo = new Date(Date.now() - 4 * 60 * 1000);
+    const past = await db
+      .select(historicPing)
+      .orderBy(desc(historicPing))
+      .where(gte(historicPing.createdAt, fourMinutesAgo))
+      .limit(4);
+
+    if (past.length === 0) {
+      // nothing to do
+      return;
+    }
+    
+    const average =
+      past.reduce((sum, row) => sum + row.ping, 0) / past.length;
+    await db.insert(historicPingAvg).values({ ping: average });
   } catch {
     console.log("Failed to log Titanium ping")
     await db.insert(historicPing).values({ ping: null });

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -27,9 +27,10 @@ cron.schedule('* * * * *', async () => {
     // get around the last 3-4 minutes to calculate average
     const fourMinutesAgo = new Date(Date.now() - 4 * 60 * 1000);
     const past = await db
-      .select(historicPing)
-      .orderBy(desc(historicPing))
-      .where(gte(historicPing.createdAt, fourMinutesAgo))
+      .select()
+      .from(historicPing)
+      .orderBy(desc(historicPing.time))
+      .where(gte(historicPing.time, fourMinutesAgo))
       .limit(4);
 
     if (past.length === 0) {
@@ -38,7 +39,7 @@ cron.schedule('* * * * *', async () => {
     }
     
     const average =
-      past.reduce((sum, row) => sum + row.ping, 0) / past.length;
+      past.reduce((sum, row) => sum + (row.ping ? row.ping : 0), 0) / past.length;
     await db.insert(historicPingAvg).values({ ping: average });
   } catch {
     console.log("Failed to log Titanium ping")

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,7 @@
 import { env } from '$env/dynamic/private';
 import cron from 'node-cron';
 
-import { desc, gte } from 'drizzle-orm';
+import { desc, gte, lte } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { historicPing, historicPingAvg } from '$lib/server/db/schema';
 
@@ -37,12 +37,16 @@ cron.schedule('* * * * *', async () => {
       // nothing to do
       return;
     }
-    
-    const average =
-      past.reduce((sum, row) => sum + (row.ping ? row.ping : 0), 0) / past.length;
+
+    const average = past.reduce((sum, row) => sum + (row.ping ? row.ping : 0), 0) / past.length;
     await db.insert(historicPingAvg).values({ ping: average });
+
+    // delete older than 3 days
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+    await db.delete(historicPing).where(lte(historicPing.time, threeDaysAgo));
+    await db.delete(historicPingAvg).where(lte(historicPingAvg.time, threeDaysAgo));
   } catch {
-    console.log("Failed to log Titanium ping")
+    console.log('Failed to log Titanium ping');
     await db.insert(historicPing).values({ ping: null });
   }
 });

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -15,7 +15,7 @@
         Restart
       </a>
     </p>
-    <div class="flex items-center gap-2 flex-wrap">
+    <div class="flex flex-wrap items-center gap-2">
       <a
         href={resolve('/server')}
         class="transition-all hover:font-bold hover:text-zinc-700 hover:dark:text-zinc-300"

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -103,7 +103,6 @@
 {#if menuOpen}
   <nav
     class="fixed inset-0 z-90 mt-12 h-fit w-full bg-linear-to-b from-zinc-300 from-75% pt-2 pb-20 dark:from-zinc-800"
-    
     transition:fly={{ y: prefersReducedMotion.current ? 0 : -10, duration: 200 }}
   >
     {@render menuLink('Home', resolve('/'), page.url.pathname.endsWith('/'), House)}

--- a/src/lib/remote/status.remote.ts
+++ b/src/lib/remote/status.remote.ts
@@ -1,7 +1,7 @@
 import { query } from '$app/server';
 import { env } from '$env/dynamic/private';
 
-import { historicPing } from '$lib/server/db/schema';
+import { historicPingAvg } from '$lib/server/db/schema';
 import { db } from '$lib/server/db';
 
 import type { botStatus } from '$lib/interfaces/status';
@@ -20,6 +20,6 @@ export const getStatus = query(async () => {
 });
 
 export const getHistoricPing = query(async () => {
-  const pings = await db.select().from(historicPing);
+  const pings = await db.select().from(historicPingAvg);
   return pings;
 });

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -104,10 +104,10 @@
   <section class="flex flex-col gap-2.5" id="fireboard">
     <h3 class="font-semibold">Fireboard</h3>
     <p>
-      Titanium provides a fireboard feature that allows guild members to highlight messages by
-      using reactions. This feature stores message IDs and corresponding channel IDs that meet
-      the critieria as set by guild moderators, but does not store message content, attachments
-      or who reacted.
+      Titanium provides a fireboard feature that allows guild members to highlight messages by using
+      reactions. This feature stores message IDs and corresponding channel IDs that meet the
+      critieria as set by guild moderators, but does not store message content, attachments or who
+      reacted.
     </p>
   </section>
 
@@ -133,10 +133,10 @@
   <section class="flex flex-col gap-2.5" id="server-counters">
     <h3 class="font-semibold">Server Counters</h3>
     <p>
-      Titanium provides server counters that allow guild members to see various statistics about
-      the guild. These counters appear as voice channels in the channel list. Titanium will store
-      the created channel ID and the counter type when a counter channel is created, as well as
-      the selected name.
+      Titanium provides server counters that allow guild members to see various statistics about the
+      guild. These counters appear as voice channels in the channel list. Titanium will store the
+      created channel ID and the counter type when a counter channel is created, as well as the
+      selected name.
     </p>
   </section>
 
@@ -146,8 +146,8 @@
       Titanium provides a confessions feature that allows guild members to anonymously share their
       confessions. This feature allows guild admins to send confession messages to a private log
       channel that contains the author of the confession, this is intended for moderation and
-      compliance purposes. You should not assume that confession messages are anonymous to a
-      guild's staff team.
+      compliance purposes. You should not assume that confession messages are anonymous to a guild's
+      staff team.
     </p>
   </section>
 
@@ -292,9 +292,9 @@
 
     <h3 class="font-semibold">User Data</h3>
     <p>
-      To remove all user related data, use the <code class="text-base">/opt-out</code> command - 
-      this will remove data such as tags and leaderboard data for your account, and block further
-      data collection of this type.
+      To remove all user related data, use the <code class="text-base">/opt-out</code> command - this
+      will remove data such as tags and leaderboard data for your account, and block further data collection
+      of this type.
     </p>
 
     <h3 class="font-semibold">Server Data</h3>


### PR DESCRIPTION
The ping graph currently is very spiky as the latency changes over time, this isn't very representative of the bot's performance as it makes it look like the bot is struggling when it's not.

<img width="1547" height="634" alt="image" src="https://github.com/user-attachments/assets/e59e9e0f-0f92-47f1-8edc-29239b6c3231" />

Ideally it would be good to calculate a rolling average over the past few latency captures